### PR TITLE
Update ./src/PSIServer.cpp for cardinality mode

### DIFF
--- a/src/PSIServer.cpp
+++ b/src/PSIServer.cpp
@@ -193,7 +193,7 @@ ServerResponse PSIServer::perform_psi(ClientRequest &req, const ExperimentParams
                     }
                     // Load the correct horizontal chunk from the server batch
                     vector<long> chunk = get_chunk(server_batch, n_slots, hi);
-                    if (params.apply_diff_privacy) {
+                    if (mode == INTERSECTION && params.apply_diff_privacy) {
                         apply_diff_privacy(chunk, fake_x_vec.at(vi), params.no_match);
                     }
                     // cout << "client index: " << vi  << " hash: " << hash_nr << " j: " << j << " hi: " << hi << " vi: " << vi << " Chunk: " << chunk << endl;


### PR DESCRIPTION
I suggest this change because if you are in the "CARDINALITY" mode, the "if" at line 196 will result in the following error during the matching:
"terminate called after throwing an instance of 'std::out_of_range'
 what(): vector::_M_range_check: __n (which is 0) >= this ->size() (which is 0)"